### PR TITLE
Fix invalid function export identifiers

### DIFF
--- a/src/api/functions.js
+++ b/src/api/functions.js
@@ -101,13 +101,13 @@ export const generateLocationIntelligence = base44.functions.generateLocationInt
 
 export const simulateHeatwaveScenario = base44.functions.simulateHeatwaveScenario;
 
-export const api/v1/getMachine = base44.functions.api/v1/getMachine;
+export const apiV1GetMachine = base44.functions["api/v1/getMachine"];
 
-export const api/v1/listRoutes = base44.functions.api/v1/listRoutes;
+export const apiV1ListRoutes = base44.functions["api/v1/listRoutes"];
 
-export const api/v1/getTelemetry = base44.functions.api/v1/getTelemetry;
+export const apiV1GetTelemetry = base44.functions["api/v1/getTelemetry"];
 
-export const webhooks/dispatchWebhook = base44.functions.webhooks/dispatchWebhook;
+export const webhooksDispatchWebhook = base44.functions["webhooks/dispatchWebhook"];
 
 export const getOpenApiSpec = base44.functions.getOpenApiSpec;
 
@@ -115,21 +115,21 @@ export const recordMetric = base44.functions.recordMetric;
 
 export const retryFailedWebhooks = base44.functions.retryFailedWebhooks;
 
-export const onboarding/recommend = base44.functions.onboarding/recommend;
+export const onboardingRecommend = base44.functions["onboarding/recommend"];
 
-export const onboarding/apply = base44.functions.onboarding/apply;
+export const onboardingApply = base44.functions["onboarding/apply"];
 
-export const onboarding/profiles = base44.functions.onboarding/profiles;
+export const onboardingProfiles = base44.functions["onboarding/profiles"];
 
-export const credentials/collectCredentials = base44.functions.credentials/collectCredentials;
+export const credentialsCollectCredentials = base44.functions["credentials/collectCredentials"];
 
-export const accounting/connectProvider = base44.functions.accounting/connectProvider;
+export const accountingConnectProvider = base44.functions["accounting/connectProvider"];
 
-export const accounting/completeConnection = base44.functions.accounting/completeConnection;
+export const accountingCompleteConnection = base44.functions["accounting/completeConnection"];
 
-export const banking/connectBank = base44.functions.banking/connectBank;
+export const bankingConnectBank = base44.functions["banking/connectBank"];
 
-export const reconciliation/autoMatch = base44.functions.reconciliation/autoMatch;
+export const reconciliationAutoMatch = base44.functions["reconciliation/autoMatch"];
 
 export const submitRefundRequest = base44.functions.submitRefundRequest;
 
@@ -155,13 +155,13 @@ export const setupMockData = base44.functions.setupMockData;
 
 export const completeOnboarding = base44.functions.completeOnboarding;
 
-export const ai/softDeleteConversation = base44.functions.ai/softDeleteConversation;
+export const aiSoftDeleteConversation = base44.functions["ai/softDeleteConversation"];
 
-export const ai/restoreConversation = base44.functions.ai/restoreConversation;
+export const aiRestoreConversation = base44.functions["ai/restoreConversation"];
 
-export const ai/purgeConversation = base44.functions.ai/purgeConversation;
+export const aiPurgeConversation = base44.functions["ai/purgeConversation"];
 
-export const ai/purgeExpiredConversations = base44.functions.ai/purgeExpiredConversations;
+export const aiPurgeExpiredConversations = base44.functions["ai/purgeExpiredConversations"];
 
 export const submitHelpFeedback = base44.functions.submitHelpFeedback;
 

--- a/src/components/ai/ConversationTrash.jsx
+++ b/src/components/ai/ConversationTrash.jsx
@@ -1,8 +1,8 @@
 
 import React, { useState, useEffect } from 'react';
 import { AiConversation } from '@/api/entities';
-import { restoreConversation } from '@/api/functions';
-import { purgeConversation } from '@/api/functions';
+import { aiRestoreConversation } from '@/api/functions';
+import { aiPurgeConversation } from '@/api/functions';
 import { PageSkeleton } from '../components/shared/Skeletons';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -44,7 +44,7 @@ export default function ConversationTrash() {
 
   const handleRestore = async (conversationId) => {
     try {
-      await restoreConversation({ conversationId });
+      await aiRestoreConversation({ conversationId });
       toast.success('Conversation restored.');
       loadTrashedConversations();
     } catch (error) {
@@ -60,7 +60,7 @@ export default function ConversationTrash() {
   const handleConfirmPurge = async () => {
     if (!selectedConvo) return;
     try {
-      await purgeConversation({ conversationId: selectedConvo.id });
+      await aiPurgeConversation({ conversationId: selectedConvo.id });
       toast.success('Conversation permanently deleted.');
       loadTrashedConversations();
     } catch (error) {

--- a/src/components/credentials/CredentialsCollector.jsx
+++ b/src/components/credentials/CredentialsCollector.jsx
@@ -10,7 +10,7 @@ import {
   CheckCircle, AlertCircle, ExternalLink, Eye, EyeOff, 
   TestTube, Shield, Key, Settings, ArrowRight
 } from 'lucide-react';
-import { collectCredentials } from '@/api/functions';
+import { credentialsCollectCredentials } from '@/api/functions';
 import { toast } from 'sonner';
 import StepUpDialog from '../auth/StepUpDialog';
 
@@ -32,7 +32,7 @@ export default function CredentialsCollector({ onComplete }) {
   const discoverRequiredCredentials = async () => {
     try {
       setLoading(true);
-      const response = await collectCredentials({
+      const response = await credentialsCollectCredentials({
         action: 'discover_required'
       });
       
@@ -72,7 +72,7 @@ export default function CredentialsCollector({ onComplete }) {
     try {
       setTesting(prev => ({ ...prev, [provider.provider_id]: true }));
       
-      const response = await collectCredentials({
+      const response = await credentialsCollectCredentials({
         action: 'test_credentials',
         provider_id: provider.provider_id,
         credentials: credentials[provider.provider_id]
@@ -115,7 +115,7 @@ export default function CredentialsCollector({ onComplete }) {
       );
       
       for (const provider of providers) {
-        const response = await collectCredentials({
+        const response = await credentialsCollectCredentials({
           action: 'save_credentials',
           provider_id: provider.provider_id,
           credentials: credentials[provider.provider_id],

--- a/src/components/onboarding/SecretsWizard.jsx
+++ b/src/components/onboarding/SecretsWizard.jsx
@@ -22,7 +22,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import StepUpDialog from '../auth/StepUpDialog';
-import { collectCredentials } from '@/api/functions';
+import { credentialsCollectCredentials } from '@/api/functions';
 
 const WIZARD_STEPS = [
   { id: 'overview', title: 'Overview & Safety', icon: Shield },
@@ -374,7 +374,7 @@ export default function SecretsWizard({ onComplete }) {
       
       for (const [key, value] of filledSecrets) {
         try {
-          await collectCredentials({
+          await credentialsCollectCredentials({
             action: 'save_credentials',
             provider_id: 'system_secrets',
             credentials: { [key]: value },

--- a/src/pages/AiTrash.jsx
+++ b/src/pages/AiTrash.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { AiConversation } from '@/api/entities';
-import { restoreConversation } from '@/api/functions';
-import { purgeConversation } from '@/api/functions';
+import { aiRestoreConversation } from '@/api/functions';
+import { aiPurgeConversation } from '@/api/functions';
 import { PageSkeleton } from '../components/shared/Skeletons';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -37,7 +37,7 @@ export default function AiTrashPage() {
 
   const handleRestore = async (conversationId) => {
     try {
-      await restoreConversation({ conversationId });
+      await aiRestoreConversation({ conversationId });
       toast.success('Conversation restored.');
       loadTrashedConversations();
     } catch (error) {
@@ -53,7 +53,7 @@ export default function AiTrashPage() {
   const handleConfirmPurge = async () => {
     if (!selectedConvo) return;
     try {
-      await purgeConversation({ conversationId: selectedConvo.id });
+      await aiPurgeConversation({ conversationId: selectedConvo.id });
       toast.success('Conversation permanently deleted.');
       loadTrashedConversations();
     } catch (error) {

--- a/src/pages/FinancialIntegrations.jsx
+++ b/src/pages/FinancialIntegrations.jsx
@@ -10,9 +10,11 @@ import {
   Download, Upload, FileText, Calculator
 } from 'lucide-react';
 import { AccountingConnection, BankConnection, ReconciliationMatch } from '@/api/entities';
-import { connectProvider } from '@/api/functions';
-import { connectBank } from '@/api/functions';
-import { autoMatch } from '@/api/functions';
+import {
+  accountingConnectProvider,
+  bankingConnectBank,
+  reconciliationAutoMatch
+} from '@/api/functions';
 
 export default function FinancialIntegrationsPage() {
   const [accountingConnections, setAccountingConnections] = useState([]);
@@ -63,7 +65,7 @@ export default function FinancialIntegrationsPage() {
 
   const handleConnectAccounting = async (providerId) => {
     try {
-      const response = await connectProvider({ provider_id: providerId });
+      const response = await accountingConnectProvider({ provider_id: providerId });
       if (response.auth_url) {
         window.location.href = response.auth_url;
       }
@@ -74,7 +76,7 @@ export default function FinancialIntegrationsPage() {
 
   const handleConnectBank = async (providerType, institutionId) => {
     try {
-      const response = await connectBank({ 
+      const response = await bankingConnectBank({
         provider_type: providerType, 
         institution_id: institutionId 
       });
@@ -92,7 +94,7 @@ export default function FinancialIntegrationsPage() {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() - 7);
       
-      const response = await autoMatch({
+      const response = await reconciliationAutoMatch({
         date_range_start: startDate.toISOString(),
         date_range_end: endDate
       });

--- a/src/pages/SecretsOnboarding.jsx
+++ b/src/pages/SecretsOnboarding.jsx
@@ -19,7 +19,7 @@ import { toast } from 'sonner';
 import { TenantCredential, CredentialHealth, CredentialAuditLog } from '@/api/entities';
 import SecretField from '../components/credentials/SecretField';
 import StepUpDialog from '../components/auth/StepUpDialog';
-import { collectCredentials } from '@/api/functions';
+import { credentialsCollectCredentials } from '@/api/functions';
 import RequireRole from '../components/auth/RequireRole';
 import { format } from 'date-fns';
 
@@ -158,7 +158,7 @@ export default function SecretsOnboarding() {
       const currentCreds = credentials[providerId]?.public_fields || {};
       const updatedFields = { ...currentCreds, [fieldName]: value };
       
-      await collectCredentials({
+      await credentialsCollectCredentials({
         provider_id: providerId,
         credentials: updatedFields,
         step_up_token: stepUpToken


### PR DESCRIPTION
## Summary
- replace Base44 function exports that used invalid identifier syntax with camelCase names and bracket-access to the original keys
- update financial integrations, secrets management, and AI trash views to import and use the renamed helpers

## Testing
- npm run lint *(fails: existing prop-types/no-unused-vars errors throughout components)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b8dde49c8327b06b76d6b89eb84e