### PR TITLE
feat: modernize telemetry ingest workflows

### DIFF
--- a/src/api/functions.js
+++ b/src/api/functions.js
@@ -1,169 +1,219 @@
 import { base44 } from './base44Client';
 
-
-export const syncNayaxData = base44.functions.syncNayaxData;
-
-export const sendReportByEmail = base44.functions.sendReportByEmail;
-
-export const deleteAllData = base44.functions.deleteAllData;
-
-export const systemHealthCheck = base44.functions.systemHealthCheck;
-
-export const dailySyncAndTrain = base44.functions.dailySyncAndTrain;
-
-export const processSqsMessage = base44.functions.processSqsMessage;
-
-export const scheduledSync = base44.functions.scheduledSync;
-
-export const reauthStart = base44.functions.reauthStart;
-
-export const submitComplaintAndNotify = base44.functions.submitComplaintAndNotify;
-
-export const sendWeeklyReport = base44.functions.sendWeeklyReport;
-
-export const sendMonthlyReport = base44.functions.sendMonthlyReport;
-
-export const processVendFailure = base44.functions.processVendFailure;
-
-export const fetchWeatherData = base44.functions.fetchWeatherData;
-
-export const generateLocationScores = base44.functions.generateLocationScores;
-
-export const syncToXero = base44.functions.syncToXero;
-
-export const ping = base44.functions.ping;
-
-export const startXeroConnection = base44.functions.startXeroConnection;
-
-export const completeXeroConnection = base44.functions.completeXeroConnection;
-
-export const testWeatherApi = base44.functions.testWeatherApi;
-
-export const testTwilio = base44.functions.testTwilio;
-
-export const sendSmsAlert = base44.functions.sendSmsAlert;
-
-export const getMapsApiKey = base44.functions.getMapsApiKey;
-
-export const autoSyncNayaxData = base44.functions.autoSyncNayaxData;
-
-export const autoSyncXero = base44.functions.autoSyncXero;
-
-export const trackGA4Event = base44.functions.trackGA4Event;
-
-export const calculateStripeTax = base44.functions.calculateStripeTax;
-
-export const fetchWestpacTransactions = base44.functions.fetchWestpacTransactions;
-
-export const getGoogleAnalyticsId = base44.functions.getGoogleAnalyticsId;
-
-export const testGoogleAnalyticsApi = base44.functions.testGoogleAnalyticsApi;
-
-export const checkFeatureToggle = base44.functions.checkFeatureToggle;
-
-export const manageFeatureToggle = base44.functions.manageFeatureToggle;
-
-export const ingestTelemetryWebhook = base44.functions.ingestTelemetryWebhook;
-
-export const processTelemetryFile = base44.functions.processTelemetryFile;
-
-export const exportTelemetryData = base44.functions.exportTelemetryData;
-
-export const paymentProviderConnector = base44.functions.paymentProviderConnector;
-
-export const processRefund = base44.functions.processRefund;
-
-export const processSettlementFile = base44.functions.processSettlementFile;
-
-export const exportDeviceInventory = base44.functions.exportDeviceInventory;
-
-export const bulkDeviceUpdate = base44.functions.bulkDeviceUpdate;
-
-export const createAlert = base44.functions.createAlert;
-
-export const routeAlert = base44.functions.routeAlert;
-
-export const escalateAlerts = base44.functions.escalateAlerts;
-
-export const calculatePickList = base44.functions.calculatePickList;
-
-export const generateExpiryReport = base44.functions.generateExpiryReport;
-
-export const processLotRecall = base44.functions.processLotRecall;
-
-export const processInventoryAdjustment = base44.functions.processInventoryAdjustment;
-
-export const calculateEnergyOptimizations = base44.functions.calculateEnergyOptimizations;
-
-export const generateESGReport = base44.functions.generateESGReport;
-
-export const generateLocationIntelligence = base44.functions.generateLocationIntelligence;
-
-export const simulateHeatwaveScenario = base44.functions.simulateHeatwaveScenario;
-
-export const api/v1/getMachine = base44.functions.api/v1/getMachine;
-
-export const api/v1/listRoutes = base44.functions.api/v1/listRoutes;
-
-export const api/v1/getTelemetry = base44.functions.api/v1/getTelemetry;
-
-export const webhooks/dispatchWebhook = base44.functions.webhooks/dispatchWebhook;
-
-export const getOpenApiSpec = base44.functions.getOpenApiSpec;
-
-export const recordMetric = base44.functions.recordMetric;
-
-export const retryFailedWebhooks = base44.functions.retryFailedWebhooks;
-
-export const onboarding/recommend = base44.functions.onboarding/recommend;
-
-export const onboarding/apply = base44.functions.onboarding/apply;
-
-export const onboarding/profiles = base44.functions.onboarding/profiles;
-
-export const credentials/collectCredentials = base44.functions.credentials/collectCredentials;
-
-export const accounting/connectProvider = base44.functions.accounting/connectProvider;
-
-export const accounting/completeConnection = base44.functions.accounting/completeConnection;
-
-export const banking/connectBank = base44.functions.banking/connectBank;
-
-export const reconciliation/autoMatch = base44.functions.reconciliation/autoMatch;
-
-export const submitRefundRequest = base44.functions.submitRefundRequest;
-
-export const analyzeRefundRisk = base44.functions.analyzeRefundRisk;
-
-export const processRefundWithChecks = base44.functions.processRefundWithChecks;
-
-export const createServiceTicket = base44.functions.createServiceTicket;
-
-export const snoozeServiceTicket = base44.functions.snoozeServiceTicket;
-
-export const escalateServiceTickets = base44.functions.escalateServiceTickets;
-
-export const testNayax = base44.functions.testNayax;
-
-export const testXero = base44.functions.testXero;
-
-export const testGoogleMapsApi = base44.functions.testGoogleMapsApi;
-
-export const exportData = base44.functions.exportData;
-
-export const setupMockData = base44.functions.setupMockData;
-
-export const completeOnboarding = base44.functions.completeOnboarding;
-
-export const ai/softDeleteConversation = base44.functions.ai/softDeleteConversation;
-
-export const ai/restoreConversation = base44.functions.ai/restoreConversation;
-
-export const ai/purgeConversation = base44.functions.ai/purgeConversation;
-
-export const ai/purgeExpiredConversations = base44.functions.ai/purgeExpiredConversations;
-
-export const submitHelpFeedback = base44.functions.submitHelpFeedback;
-
-export const processPublicComplaint = base44.functions.processPublicComplaint;
-
+const getFunction = (name) => {
+  const fn = base44?.functions?.[name];
+  if (typeof fn === 'function') {
+    return fn;
+  }
+
+  return async (..._args) => {
+    throw new Error(`base44 function "${name}" is not available`);
+  };
+};
+
+const functionMap = {
+  // Core platform
+  syncNayaxData: 'syncNayaxData',
+  sendReportByEmail: 'sendReportByEmail',
+  deleteAllData: 'deleteAllData',
+  systemHealthCheck: 'systemHealthCheck',
+  dailySyncAndTrain: 'dailySyncAndTrain',
+  processSqsMessage: 'processSqsMessage',
+  scheduledSync: 'scheduledSync',
+  reauthStart: 'reauthStart',
+  submitComplaintAndNotify: 'submitComplaintAndNotify',
+  sendWeeklyReport: 'sendWeeklyReport',
+  sendMonthlyReport: 'sendMonthlyReport',
+  processVendFailure: 'processVendFailure',
+  fetchWeatherData: 'fetchWeatherData',
+  generateLocationScores: 'generateLocationScores',
+  syncToXero: 'syncToXero',
+  ping: 'ping',
+  startXeroConnection: 'startXeroConnection',
+  completeXeroConnection: 'completeXeroConnection',
+  testWeatherApi: 'testWeatherApi',
+  testTwilio: 'testTwilio',
+  sendSmsAlert: 'sendSmsAlert',
+  getMapsApiKey: 'getMapsApiKey',
+  autoSyncNayaxData: 'autoSyncNayaxData',
+  autoSyncXero: 'autoSyncXero',
+  trackGA4Event: 'trackGA4Event',
+  calculateStripeTax: 'calculateStripeTax',
+  fetchWestpacTransactions: 'fetchWestpacTransactions',
+  getGoogleAnalyticsId: 'getGoogleAnalyticsId',
+  testGoogleAnalyticsApi: 'testGoogleAnalyticsApi',
+  checkFeatureToggle: 'checkFeatureToggle',
+  manageFeatureToggle: 'manageFeatureToggle',
+
+  // Telemetry + ingest
+  ingestTelemetryWebhook: 'ingestTelemetryWebhook',
+  processTelemetryFile: 'processTelemetryFile',
+  exportTelemetryData: 'exportTelemetryData',
+  normalizeTelemetryEvents: 'telemetry/normalizeEvents',
+  submitTelemetryBatch: 'telemetry/submitBatch',
+  fetchTelemetryMonitorSummary: 'telemetry/monitorSummary',
+  replayDeadLetters: 'telemetry/replayDeadLetters',
+  exportTelemetryPayload: 'telemetry/exportPayload',
+
+  // Payments + settlements
+  paymentProviderConnector: 'paymentProviderConnector',
+  processRefund: 'processRefund',
+  processSettlementFile: 'processSettlementFile',
+  submitRefundRequest: 'submitRefundRequest',
+  analyzeRefundRisk: 'analyzeRefundRisk',
+  processRefundWithChecks: 'processRefundWithChecks',
+
+  // Devices + inventory
+  exportDeviceInventory: 'exportDeviceInventory',
+  bulkDeviceUpdate: 'bulkDeviceUpdate',
+  calculatePickList: 'calculatePickList',
+  generateExpiryReport: 'generateExpiryReport',
+  processLotRecall: 'processLotRecall',
+  processInventoryAdjustment: 'processInventoryAdjustment',
+
+  // Alerts + service
+  createAlert: 'createAlert',
+  routeAlert: 'routeAlert',
+  escalateAlerts: 'escalateAlerts',
+  createServiceTicket: 'createServiceTicket',
+  snoozeServiceTicket: 'snoozeServiceTicket',
+  escalateServiceTickets: 'escalateServiceTickets',
+
+  // Energy + intelligence
+  calculateEnergyOptimizations: 'calculateEnergyOptimizations',
+  generateESGReport: 'generateESGReport',
+  generateLocationIntelligence: 'generateLocationIntelligence',
+  simulateHeatwaveScenario: 'simulateHeatwaveScenario',
+
+  // API + webhooks
+  getMachine: 'api/v1/getMachine',
+  listRoutes: 'api/v1/listRoutes',
+  getTelemetry: 'api/v1/getTelemetry',
+  dispatchWebhook: 'webhooks/dispatchWebhook',
+  getOpenApiSpec: 'getOpenApiSpec',
+  recordMetric: 'recordMetric',
+  retryFailedWebhooks: 'retryFailedWebhooks',
+
+  // Onboarding + credentials
+  onboardingRecommend: 'onboarding/recommend',
+  onboardingApply: 'onboarding/apply',
+  onboardingProfiles: 'onboarding/profiles',
+  collectCredentials: 'credentials/collectCredentials',
+  connectProvider: 'accounting/connectProvider',
+  completeConnection: 'accounting/completeConnection',
+  connectBank: 'banking/connectBank',
+  autoMatch: 'reconciliation/autoMatch',
+
+  // AI helpers used in UI
+  softDeleteConversation: 'ai/softDeleteConversation',
+  restoreConversation: 'ai/restoreConversation',
+  purgeConversation: 'ai/purgeConversation',
+  purgeExpiredConversations: 'ai/purgeExpiredConversations',
+
+  // Misc utilities
+  exportData: 'exportData',
+  setupMockData: 'setupMockData',
+  completeOnboarding: 'completeOnboarding',
+  submitHelpFeedback: 'submitHelpFeedback',
+  processPublicComplaint: 'processPublicComplaint',
+  testNayax: 'testNayax',
+  testXero: 'testXero',
+  testGoogleMapsApi: 'testGoogleMapsApi'
+};
+
+const apiFunctions = Object.fromEntries(
+  Object.entries(functionMap).map(([exportName, remoteName]) => [exportName, getFunction(remoteName)])
+);
+
+export const {
+  syncNayaxData,
+  sendReportByEmail,
+  deleteAllData,
+  systemHealthCheck,
+  dailySyncAndTrain,
+  processSqsMessage,
+  scheduledSync,
+  reauthStart,
+  submitComplaintAndNotify,
+  sendWeeklyReport,
+  sendMonthlyReport,
+  processVendFailure,
+  fetchWeatherData,
+  generateLocationScores,
+  syncToXero,
+  ping,
+  startXeroConnection,
+  completeXeroConnection,
+  testWeatherApi,
+  testTwilio,
+  sendSmsAlert,
+  getMapsApiKey,
+  autoSyncNayaxData,
+  autoSyncXero,
+  trackGA4Event,
+  calculateStripeTax,
+  fetchWestpacTransactions,
+  getGoogleAnalyticsId,
+  testGoogleAnalyticsApi,
+  checkFeatureToggle,
+  manageFeatureToggle,
+  ingestTelemetryWebhook,
+  processTelemetryFile,
+  exportTelemetryData,
+  normalizeTelemetryEvents,
+  submitTelemetryBatch,
+  fetchTelemetryMonitorSummary,
+  replayDeadLetters,
+  exportTelemetryPayload,
+  paymentProviderConnector,
+  processRefund,
+  processSettlementFile,
+  submitRefundRequest,
+  analyzeRefundRisk,
+  processRefundWithChecks,
+  exportDeviceInventory,
+  bulkDeviceUpdate,
+  calculatePickList,
+  generateExpiryReport,
+  processLotRecall,
+  processInventoryAdjustment,
+  createAlert,
+  routeAlert,
+  escalateAlerts,
+  createServiceTicket,
+  snoozeServiceTicket,
+  escalateServiceTickets,
+  calculateEnergyOptimizations,
+  generateESGReport,
+  generateLocationIntelligence,
+  simulateHeatwaveScenario,
+  getMachine,
+  listRoutes,
+  getTelemetry,
+  dispatchWebhook,
+  getOpenApiSpec,
+  recordMetric,
+  retryFailedWebhooks,
+  onboardingRecommend,
+  onboardingApply,
+  onboardingProfiles,
+  collectCredentials,
+  connectProvider,
+  completeConnection,
+  connectBank,
+  autoMatch,
+  softDeleteConversation,
+  restoreConversation,
+  purgeConversation,
+  purgeExpiredConversations,
+  exportData,
+  setupMockData,
+  completeOnboarding,
+  submitHelpFeedback,
+  processPublicComplaint,
+  testNayax,
+  testXero,
+  testGoogleMapsApi
+} = apiFunctions;
+
+export default apiFunctions;

--- a/src/pages/telemetry.jsx
+++ b/src/pages/telemetry.jsx
@@ -4,13 +4,32 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { 
-  Activity, Upload, Download, AlertTriangle, CheckCircle2, 
-  Clock, Zap, Database, FileText, Settings
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import {
+  Activity, Upload, Download, AlertTriangle, CheckCircle2,
+  Clock, Zap, Database, Settings, RefreshCw, ShieldAlert,
+  History, Link2, Repeat, ShieldCheck, Timer, FileText
 } from 'lucide-react';
 import LoadingSpinner from '../components/shared/LoadingSpinner';
 import { toast } from 'sonner';
-import { format } from 'date-fns';
+import { format, formatDistanceToNow } from 'date-fns';
 
 // Import entities
 import { TelemetryIngestJob } from '@/api/entities';
@@ -18,8 +37,45 @@ import { DeadLetterQueue } from '@/api/entities';
 import { MachineRegistry } from '@/api/entities';
 import { TelemetryReading } from '@/api/entities';
 import { UploadFile } from '@/api/integrations';
-import { processTelemetryFile } from '@/api/functions';
-import { exportTelemetryData } from '@/api/functions';
+import {
+  normalizeTelemetryEvents,
+  submitTelemetryBatch,
+  fetchTelemetryMonitorSummary,
+  replayDeadLetters,
+  exportTelemetryPayload
+} from '@/api/functions';
+
+const createIdempotencyKey = (prefix = 'telemetry') => {
+  const base = `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  return base.replace(/[^a-zA-Z0-9_\-]/g, '_');
+};
+
+const buildDefaultSummary = () => ({
+  deviceMappings: {
+    mapped: 0,
+    unmapped: 0,
+    total: 0,
+    unmappedDevices: []
+  },
+  duplicateSuppression: {
+    suppressed: 0,
+    windowSeconds: 300
+  },
+  schemaVersions: {
+    expected: '',
+    lastSeen: '',
+    mismatches: 0,
+    mismatchedMachines: []
+  },
+  gapAlerts: [],
+  lastEventTimestamps: [],
+  retryStats: {
+    pending: 0,
+    scheduled: 0,
+    lastReplayAt: null
+  },
+  normalizationLagSeconds: null
+});
 
 export default function TelemetryPage() {
   const [activeTab, setActiveTab] = useState('monitor');
@@ -29,6 +85,60 @@ export default function TelemetryPage() {
   const [recentReadings, setRecentReadings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [processing, setProcessing] = useState(false);
+  const [fileUpload, setFileUpload] = useState(null);
+  const [ingestSummary, setIngestSummary] = useState(buildDefaultSummary());
+  const [fileNormalizationResult, setFileNormalizationResult] = useState(null);
+  const [eventNormalizationResult, setEventNormalizationResult] = useState(null);
+  const [exportResult, setExportResult] = useState(null);
+  const [submittingEvents, setSubmittingEvents] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [replayDialogOpen, setReplayDialogOpen] = useState(false);
+  const [selectedDeadLetter, setSelectedDeadLetter] = useState(null);
+  const [replaying, setReplaying] = useState(false);
+
+  const [fileForm, setFileForm] = useState({
+    tenantId: '',
+    machineId: '',
+    deviceId: '',
+    vendor: '',
+    ingestionChannel: 'portal_upload',
+    schemaVersion: '2024-01',
+    format: 'dex',
+    dedupeWindow: 300,
+    submittedBy: '',
+    metadata: '',
+    idempotencyKey: createIdempotencyKey('file')
+  });
+
+  const [eventForm, setEventForm] = useState({
+    tenantId: '',
+    machineId: '',
+    deviceId: '',
+    ingestionChannel: 'portal_api',
+    schemaVersion: '2024-01',
+    submittedBy: '',
+    metadata: '',
+    eventsJson: '',
+    idempotencyKey: createIdempotencyKey('event')
+  });
+
+  const [exportForm, setExportForm] = useState({
+    tenantId: '',
+    startDate: '',
+    endDate: '',
+    machineId: '',
+    dataTypes: ['vend', 'errors'],
+    format: 'jsonl',
+    includeSchema: true,
+    idempotencyKey: createIdempotencyKey('export')
+  });
+
+  const [replayForm, setReplayForm] = useState({
+    tenantId: '',
+    idempotencyKey: createIdempotencyKey('replay'),
+    maxRetries: 1,
+    note: ''
+  });
 
   useEffect(() => {
     loadTelemetryData();
@@ -36,17 +146,42 @@ export default function TelemetryPage() {
 
   const loadTelemetryData = async () => {
     try {
-      const [jobs, dlq, registry, readings] = await Promise.all([
+      const [jobs, dlq, registry, readings, summaryResponse] = await Promise.all([
         TelemetryIngestJob.list('-started_at', 50),
         DeadLetterQueue.filter({ status: 'failed' }, '-failed_at', 25),
         MachineRegistry.list(),
-        TelemetryReading.list('-ingested_at', 100)
+        TelemetryReading.list('-ingested_at', 100),
+        fetchTelemetryMonitorSummary()
       ]);
-      
+
       setIngestJobs(jobs);
       setDeadLetterQueue(dlq);
       setMachineRegistry(registry);
       setRecentReadings(readings);
+
+      const defaultSummary = buildDefaultSummary();
+      const summaryData = summaryResponse?.data || summaryResponse || {};
+      setIngestSummary({
+        deviceMappings: {
+          ...defaultSummary.deviceMappings,
+          ...(summaryData.deviceMappings || {})
+        },
+        duplicateSuppression: {
+          ...defaultSummary.duplicateSuppression,
+          ...(summaryData.duplicateSuppression || {})
+        },
+        schemaVersions: {
+          ...defaultSummary.schemaVersions,
+          ...(summaryData.schemaVersions || {})
+        },
+        gapAlerts: summaryData.gapAlerts || defaultSummary.gapAlerts,
+        lastEventTimestamps: summaryData.lastEventTimestamps || defaultSummary.lastEventTimestamps,
+        retryStats: {
+          ...defaultSummary.retryStats,
+          ...(summaryData.retryStats || {})
+        },
+        normalizationLagSeconds: summaryData.normalizationLagSeconds ?? defaultSummary.normalizationLagSeconds
+      });
     } catch (error) {
       console.error('Error loading telemetry data:', error);
       toast.error('Failed to load telemetry data');
@@ -55,82 +190,275 @@ export default function TelemetryPage() {
     }
   };
 
-  const handleFileUpload = async (event) => {
-    const file = event.target.files[0];
-    if (!file) return;
+  const handleFileUploadChange = (event) => {
+    const file = event.target.files?.[0];
+    setFileUpload(file || null);
+  };
+
+  const parseMetadataField = (value) => {
+    if (!value || !value.trim()) return undefined;
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      throw new Error('Metadata must be valid JSON');
+    }
+  };
+
+  const handleFileIngestSubmit = async (event) => {
+    event.preventDefault();
+    if (!fileUpload) {
+      toast.error('Select a file to upload');
+      return;
+    }
+
+    if (!fileForm.tenantId || !fileForm.machineId || !fileForm.idempotencyKey) {
+      toast.error('Tenant, machine and idempotency key are required');
+      return;
+    }
 
     setProcessing(true);
+    setFileNormalizationResult(null);
+
     try {
-      const { file_url } = await UploadFile({ file });
-      
-      const machineId = prompt('Enter machine ID:');
-      const format = prompt('Enter file format (dex, eva-dts):')?.toLowerCase();
-      
-      if (!machineId || !format) {
-        toast.error('Machine ID and format are required');
-        return;
+      const uploadResult = await UploadFile({ file: fileUpload });
+      const fileUrl = uploadResult?.file_url || uploadResult?.data?.file_url;
+
+      if (!fileUrl) {
+        throw new Error('Upload response missing file URL');
       }
-      
-      const response = await processTelemetryFile({
-        file_url,
-        machine_id: machineId,
-        format
-      });
-      
-      if (response.data?.success) {
-        toast.success(`File processed successfully: ${response.data.processed} records processed`);
-        loadTelemetryData();
-      } else {
-        toast.error(`Processing failed: ${response.data?.error || 'Unknown error'}`);
+
+      const metadata = parseMetadataField(fileForm.metadata);
+
+      const normalizationPayload = {
+        transport: 'file',
+        tenant_id: fileForm.tenantId,
+        idempotency_key: fileForm.idempotencyKey,
+        schema_version: fileForm.schemaVersion,
+        format: fileForm.format,
+        file_url: fileUrl,
+        dedupe_window_seconds: Number(fileForm.dedupeWindow) || 0,
+        source: {
+          machine_id: fileForm.machineId,
+          device_id: fileForm.deviceId || undefined,
+          vendor: fileForm.vendor || undefined,
+          ingestion_channel: fileForm.ingestionChannel,
+          submitted_by: fileForm.submittedBy || undefined
+        },
+        metadata
+      };
+
+      const normalizationResponse = await normalizeTelemetryEvents(normalizationPayload);
+      const normalizationData = normalizationResponse?.data || normalizationResponse || {};
+      setFileNormalizationResult(normalizationData.summary || normalizationData);
+
+      const normalizedEvents = normalizationData.normalized_events || normalizationData.events;
+      if (normalizedEvents && normalizedEvents.length > 0) {
+        await submitTelemetryBatch({
+          tenant_id: fileForm.tenantId,
+          idempotency_key: fileForm.idempotencyKey,
+          normalized_events: normalizedEvents,
+          source: normalizationPayload.source,
+          schema_version: fileForm.schemaVersion,
+          dedupe_window_seconds: Number(fileForm.dedupeWindow) || undefined,
+          metadata
+        });
       }
-      
+
+      toast.success('Telemetry file normalized and queued for ingestion');
+      setFileForm((current) => ({
+        ...current,
+        metadata: '',
+        idempotencyKey: createIdempotencyKey('file')
+      }));
+      setFileUpload(null);
+      event.target.reset();
+      loadTelemetryData();
     } catch (error) {
-      console.error('Upload error:', error);
-      toast.error('File upload failed');
+      console.error('File ingest error:', error);
+      toast.error(error?.message || 'File ingest failed');
     } finally {
       setProcessing(false);
     }
   };
 
-  const handleExport = async (format) => {
+  const handleEventSubmit = async (event) => {
+    event.preventDefault();
+    if (!eventForm.eventsJson.trim()) {
+      toast.error('Add at least one event payload');
+      return;
+    }
+
+    if (!eventForm.tenantId || !eventForm.machineId || !eventForm.idempotencyKey) {
+      toast.error('Tenant, machine and idempotency key are required');
+      return;
+    }
+
+    let parsedEvents;
     try {
-      const startDate = prompt('Start date (YYYY-MM-DD):');
-      const endDate = prompt('End date (YYYY-MM-DD):');
-      
-      if (!startDate || !endDate) {
-        toast.error('Start and end dates are required');
-        return;
+      parsedEvents = JSON.parse(eventForm.eventsJson);
+    } catch (error) {
+      toast.error('Events JSON must be valid');
+      return;
+    }
+
+    const normalizationPayload = {
+      transport: 'inline',
+      tenant_id: eventForm.tenantId,
+      idempotency_key: eventForm.idempotencyKey,
+      schema_version: eventForm.schemaVersion,
+      events: Array.isArray(parsedEvents) ? parsedEvents : [parsedEvents],
+      source: {
+        machine_id: eventForm.machineId,
+        device_id: eventForm.deviceId || undefined,
+        ingestion_channel: eventForm.ingestionChannel,
+        submitted_by: eventForm.submittedBy || undefined
+      },
+      metadata: parseMetadataField(eventForm.metadata)
+    };
+
+    setSubmittingEvents(true);
+    setEventNormalizationResult(null);
+
+    try {
+      const normalizationResponse = await normalizeTelemetryEvents(normalizationPayload);
+      const normalizationData = normalizationResponse?.data || normalizationResponse || {};
+      setEventNormalizationResult(normalizationData.summary || normalizationData);
+
+      const normalizedEvents = normalizationData.normalized_events || normalizationData.events;
+      if (normalizedEvents && normalizedEvents.length > 0) {
+        await submitTelemetryBatch({
+          tenant_id: eventForm.tenantId,
+          idempotency_key: eventForm.idempotencyKey,
+          normalized_events: normalizedEvents,
+          source: normalizationPayload.source,
+          schema_version: eventForm.schemaVersion,
+          metadata: normalizationPayload.metadata
+        });
       }
-      
-      const response = await exportTelemetryData({
-        export_format: format,
-        start_date: `${startDate}T00:00:00Z`,
-        end_date: `${endDate}T23:59:59Z`
-      });
-      
-      if (format === 'parquet') {
-        const blob = new Blob([JSON.stringify(response.data.data, null, 2)], { type: 'application/json' });
+
+      toast.success('Telemetry events normalized and submitted');
+      setEventForm((current) => ({
+        ...current,
+        metadata: '',
+        eventsJson: '',
+        idempotencyKey: createIdempotencyKey('event')
+      }));
+      loadTelemetryData();
+    } catch (error) {
+      console.error('Event ingest error:', error);
+      toast.error(error?.message || 'Event submission failed');
+    } finally {
+      setSubmittingEvents(false);
+    }
+  };
+
+  const handleExportSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!exportForm.tenantId || !exportForm.startDate || !exportForm.endDate) {
+      toast.error('Tenant and date range are required');
+      return;
+    }
+
+    setExporting(true);
+    setExportResult(null);
+
+    try {
+      const payload = {
+        tenant_id: exportForm.tenantId,
+        idempotency_key: exportForm.idempotencyKey,
+        range: {
+          start: `${exportForm.startDate}T00:00:00Z`,
+          end: `${exportForm.endDate}T23:59:59Z`
+        },
+        machine_id: exportForm.machineId || undefined,
+        data_types: exportForm.dataTypes,
+        format: exportForm.format,
+        include_schema: exportForm.includeSchema,
+        validation: {
+          schema: 'TelemetryEvent',
+          strict: true
+        }
+      };
+
+      const response = await exportTelemetryPayload(payload);
+      const exportData = response?.data || response || {};
+
+      if (exportData.download_url) {
+        window.open(exportData.download_url, '_blank');
+      } else if (exportData.file_name && exportData.content) {
+        const mimeType = exportForm.format === 'parquet' ? 'application/octet-stream' : 'application/json';
+        const blob = new Blob([
+          exportForm.format === 'jsonl'
+            ? (Array.isArray(exportData.content) ? exportData.content.join('\n') : exportData.content)
+            : exportData.content
+        ], { type: mimeType });
         const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `telemetry_export_${startDate}_${endDate}.json`;
-        a.click();
-        URL.revokeObjectURL(url);
-      } else {
-        const blob = new Blob([response.data], { type: 'text/plain' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `telemetry_export_${startDate}_${endDate}.${format}`;
-        a.click();
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = exportData.file_name;
+        anchor.click();
         URL.revokeObjectURL(url);
       }
-      
-      toast.success(`Export completed in ${format.toUpperCase()} format`);
-      
+
+      setExportResult(exportData.summary || exportData);
+      toast.success(`Export job created (${exportForm.format.toUpperCase()})`);
+      setExportForm((current) => ({
+        ...current,
+        idempotencyKey: createIdempotencyKey('export')
+      }));
     } catch (error) {
       console.error('Export error:', error);
-      toast.error('Export failed');
+      toast.error(error?.message || 'Export failed');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const openReplayDialog = (message) => {
+    setSelectedDeadLetter(message);
+    setReplayForm((current) => ({
+      ...current,
+      tenantId: message?.tenant_id || '',
+      idempotencyKey: createIdempotencyKey('replay'),
+      note: ''
+    }));
+    setReplayDialogOpen(true);
+  };
+
+  const handleReplaySubmit = async (event) => {
+    event.preventDefault();
+    if (!selectedDeadLetter) return;
+
+    if (!replayForm.tenantId) {
+      toast.error('Tenant scope is required to replay');
+      return;
+    }
+
+    setReplaying(true);
+    try {
+      const payload = {
+        tenant_id: replayForm.tenantId,
+        idempotency_key: replayForm.idempotencyKey,
+        message_ids: [selectedDeadLetter.id],
+        max_retries: Number(replayForm.maxRetries) || 1,
+        note: replayForm.note || undefined
+      };
+
+      await replayDeadLetters(payload);
+      toast.success('Replay scheduled');
+      setReplayDialogOpen(false);
+      setSelectedDeadLetter(null);
+      setReplayForm((current) => ({
+        ...current,
+        idempotencyKey: createIdempotencyKey('replay')
+      }));
+      loadTelemetryData();
+    } catch (error) {
+      console.error('Replay error:', error);
+      toast.error(error?.message || 'Failed to schedule replay');
+    } finally {
+      setReplaying(false);
     }
   };
 
@@ -143,6 +471,14 @@ export default function TelemetryPage() {
       default: return 'bg-gray-100 text-gray-800';
     }
   };
+
+  const mappingCoverage = ingestSummary.deviceMappings.total
+    ? Math.round((ingestSummary.deviceMappings.mapped / ingestSummary.deviceMappings.total) * 100)
+    : 0;
+
+  const normalizationLagDisplay = ingestSummary.normalizationLagSeconds != null
+    ? formatDistanceToNow(new Date(Date.now() - ingestSummary.normalizationLagSeconds * 1000), { addSuffix: true })
+    : '—';
 
   if (loading) {
     return (
@@ -187,69 +523,224 @@ export default function TelemetryPage() {
 
           <TabsContent value="monitor" className="mt-6">
             <div className="grid gap-6">
-              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                <Card>
-                  <CardContent className="p-6">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm text-slate-600">Active Jobs</p>
-                        <p className="text-2xl font-bold">
-                          {ingestJobs.filter(j => j.status === 'processing').length}
-                        </p>
-                      </div>
-                      <Clock className="w-8 h-8 text-blue-600" />
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4">
+              <Card className="xl:col-span-1">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Active Jobs</p>
+                      <p className="text-2xl font-bold">
+                        {ingestJobs.filter(j => j.status === 'processing').length}
+                      </p>
                     </div>
-                  </CardContent>
-                </Card>
+                    <Clock className="w-8 h-8 text-blue-600" />
+                  </div>
+                </CardContent>
+              </Card>
 
-                <Card>
-                  <CardContent className="p-6">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm text-slate-600">Failed Messages</p>
-                        <p className="text-2xl font-bold text-red-600">
-                          {deadLetterQueue.length}
-                        </p>
-                      </div>
-                      <AlertTriangle className="w-8 h-8 text-red-600" />
+              <Card className="xl:col-span-1">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Failed Messages</p>
+                      <p className="text-2xl font-bold text-red-600">
+                        {deadLetterQueue.length}
+                      </p>
                     </div>
-                  </CardContent>
-                </Card>
+                    <AlertTriangle className="w-8 h-8 text-red-600" />
+                  </div>
+                </CardContent>
+              </Card>
 
-                <Card>
-                  <CardContent className="p-6">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm text-slate-600">Recent Readings</p>
-                        <p className="text-2xl font-bold">
-                          {recentReadings.length}
-                        </p>
-                      </div>
-                      <Zap className="w-8 h-8 text-green-600" />
+              <Card className="xl:col-span-1">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Recent Readings</p>
+                      <p className="text-2xl font-bold">
+                        {recentReadings.length}
+                      </p>
                     </div>
-                  </CardContent>
-                </Card>
+                    <Zap className="w-8 h-8 text-green-600" />
+                  </div>
+                </CardContent>
+              </Card>
 
-                <Card>
-                  <CardContent className="p-6">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm text-slate-600">Registered Machines</p>
-                        <p className="text-2xl font-bold">
-                          {machineRegistry.filter(m => m.status === 'active').length}
-                        </p>
-                      </div>
-                      <CheckCircle2 className="w-8 h-8 text-green-600" />
+              <Card className="xl:col-span-1">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Registered Machines</p>
+                      <p className="text-2xl font-bold">
+                        {machineRegistry.filter(m => m.status === 'active').length}
+                      </p>
                     </div>
-                  </CardContent>
-                </Card>
-              </div>
+                    <CheckCircle2 className="w-8 h-8 text-green-600" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="xl:col-span-1">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Duplicates Suppressed</p>
+                      <p className="text-2xl font-bold">
+                        {ingestSummary.duplicateSuppression.suppressed}
+                      </p>
+                      <p className="text-xs text-slate-500 mt-1">
+                        {ingestSummary.duplicateSuppression.windowSeconds}s window
+                      </p>
+                    </div>
+                    <RefreshCw className="w-8 h-8 text-indigo-600" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="xl:col-span-1">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Schema Mismatches</p>
+                      <p className="text-2xl font-bold text-amber-600">
+                        {ingestSummary.schemaVersions.mismatches}
+                      </p>
+                      <p className="text-xs text-slate-500 mt-1">
+                        Expected {ingestSummary.schemaVersions.expected || '—'}
+                      </p>
+                    </div>
+                    <ShieldAlert className="w-8 h-8 text-amber-600" />
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Card>
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Mapping Coverage</p>
+                      <p className="text-2xl font-bold">{mappingCoverage}%</p>
+                      <p className="text-xs text-slate-500 mt-1">
+                        {ingestSummary.deviceMappings.mapped} mapped / {ingestSummary.deviceMappings.total} devices
+                      </p>
+                    </div>
+                    <Link2 className="w-8 h-8 text-blue-600" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Retry Queue</p>
+                      <p className="text-2xl font-bold">
+                        {ingestSummary.retryStats.pending + ingestSummary.retryStats.scheduled}
+                      </p>
+                      <p className="text-xs text-slate-500 mt-1">
+                        {ingestSummary.retryStats.pending} pending • {ingestSummary.retryStats.scheduled} scheduled
+                      </p>
+                    </div>
+                    <Repeat className="w-8 h-8 text-purple-600" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-slate-600">Normalization Lag</p>
+                      <p className="text-2xl font-bold">
+                        {ingestSummary.normalizationLagSeconds != null
+                          ? `${Math.round(ingestSummary.normalizationLagSeconds / 60)}m`
+                          : '—'}
+                      </p>
+                      <p className="text-xs text-slate-500 mt-1">Last catch-up {normalizationLagDisplay}</p>
+                    </div>
+                    <Timer className="w-8 h-8 text-slate-600" />
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <History className="w-5 h-5 text-slate-600" />
+                    Latest Event Activity
+                  </CardTitle>
+                  <CardDescription>Last normalized events per machine</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3">
+                    {ingestSummary.lastEventTimestamps.length === 0 && (
+                      <p className="text-sm text-slate-500">No events processed in the recent window.</p>
+                    )}
+
+                    {ingestSummary.lastEventTimestamps.slice(0, 6).map((item) => (
+                      <div key={item.machineId} className="flex items-center justify-between rounded-lg border p-3">
+                        <div>
+                          <p className="font-medium text-slate-800">Machine {item.machineId}</p>
+                          <p className="text-xs text-slate-500">
+                            {item.deviceId ? `Device ${item.deviceId} • ` : ''}
+                            {item.timestamp ? formatDistanceToNow(new Date(item.timestamp), { addSuffix: true }) : 'Unknown'}
+                          </p>
+                        </div>
+                        <Badge className={item.status === 'healthy' ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'}>
+                          {item.status || 'unknown'}
+                        </Badge>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
 
               <Card>
                 <CardHeader>
-                  <CardTitle>Recent Ingestion Jobs</CardTitle>
-                  <CardDescription>
-                    Latest telemetry processing jobs and their status
+                  <CardTitle className="flex items-center gap-2">
+                    <ShieldCheck className="w-5 h-5 text-emerald-600" />
+                    Gap Detection Alerts
+                  </CardTitle>
+                  <CardDescription>Machines with missing or stale telemetry</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {ingestSummary.gapAlerts.length === 0 ? (
+                    <p className="text-sm text-slate-500">No gaps detected across monitored machines.</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {ingestSummary.gapAlerts.map((alert) => (
+                        <div key={`${alert.machineId}-${alert.lastEventAt}`} className="rounded-lg border border-amber-200 bg-amber-50 p-3">
+                          <div className="flex items-center justify-between">
+                            <div>
+                              <p className="font-medium text-amber-900">Machine {alert.machineId}</p>
+                              <p className="text-xs text-amber-800">
+                                Last event {alert.lastEventAt ? formatDistanceToNow(new Date(alert.lastEventAt), { addSuffix: true }) : 'unknown'}
+                              </p>
+                            </div>
+                            <Badge className="bg-amber-200 text-amber-900">
+                              {alert.severity?.toUpperCase() || 'GAP'}
+                            </Badge>
+                          </div>
+                          <p className="mt-2 text-sm text-amber-900">
+                            {alert.gapDurationMinutes ? `${alert.gapDurationMinutes} minutes without events` : 'Telemetry gap detected'}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Recent Ingestion Jobs</CardTitle>
+                <CardDescription>
+                  Latest telemetry processing jobs and their status
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -313,7 +804,7 @@ export default function TelemetryPage() {
                               Failed: {format(new Date(dlq.failed_at), 'MMM d, HH:mm')}
                             </p>
                           </div>
-                          <Button variant="outline" size="sm">
+                          <Button variant="outline" size="sm" onClick={() => openReplayDialog(dlq)}>
                             Replay
                           </Button>
                         </div>
@@ -334,38 +825,343 @@ export default function TelemetryPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="space-y-6">
-                  <div className="border-2 border-dashed border-slate-300 rounded-lg p-8 text-center">
-                    <Upload className="w-12 h-12 text-slate-400 mx-auto mb-4" />
-                    <h3 className="text-lg font-medium mb-2">Upload Telemetry File</h3>
-                    <p className="text-slate-600 mb-4">
-                      Supports .DEX, .EVA, .JSON, and .TXT files
-                    </p>
-                    <Input
-                      type="file"
-                      accept=".dex,.eva,.json,.txt"
-                      onChange={handleFileUpload}
-                      disabled={processing}
-                      className="max-w-xs mx-auto"
+                <form className="space-y-6" onSubmit={handleFileIngestSubmit}>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="file-tenant">Tenant ID</Label>
+                      <Input
+                        id="file-tenant"
+                        value={fileForm.tenantId}
+                        onChange={(event) => setFileForm((current) => ({ ...current, tenantId: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="file-machine">Machine ID</Label>
+                      <Input
+                        id="file-machine"
+                        value={fileForm.machineId}
+                        onChange={(event) => setFileForm((current) => ({ ...current, machineId: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="file-device">Device ID</Label>
+                      <Input
+                        id="file-device"
+                        value={fileForm.deviceId}
+                        onChange={(event) => setFileForm((current) => ({ ...current, deviceId: event.target.value }))}
+                        placeholder="Optional external device identifier"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="file-vendor">Source Vendor</Label>
+                      <Input
+                        id="file-vendor"
+                        value={fileForm.vendor}
+                        onChange={(event) => setFileForm((current) => ({ ...current, vendor: event.target.value }))}
+                        placeholder="Nayax, Televend, custom, etc."
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="file-schema">Schema Version</Label>
+                      <Input
+                        id="file-schema"
+                        value={fileForm.schemaVersion}
+                        onChange={(event) => setFileForm((current) => ({ ...current, schemaVersion: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>File Format</Label>
+                      <Select
+                        value={fileForm.format}
+                        onValueChange={(value) => setFileForm((current) => ({ ...current, format: value }))}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select format" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="dex">DEX</SelectItem>
+                          <SelectItem value="eva-dts">EVA-DTS</SelectItem>
+                          <SelectItem value="json">JSON</SelectItem>
+                          <SelectItem value="csv">CSV</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Ingestion Channel</Label>
+                      <Select
+                        value={fileForm.ingestionChannel}
+                        onValueChange={(value) => setFileForm((current) => ({ ...current, ingestionChannel: value }))}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select channel" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="portal_upload">Portal upload</SelectItem>
+                          <SelectItem value="sftp_drop">SFTP drop</SelectItem>
+                          <SelectItem value="iot_gateway">IoT gateway</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="file-submitted">Submitted By</Label>
+                      <Input
+                        id="file-submitted"
+                        value={fileForm.submittedBy}
+                        onChange={(event) => setFileForm((current) => ({ ...current, submittedBy: event.target.value }))}
+                        placeholder="Operator, automation, etc."
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="file-dedupe">Duplicate Window (seconds)</Label>
+                      <Input
+                        id="file-dedupe"
+                        type="number"
+                        min={0}
+                        value={fileForm.dedupeWindow}
+                        onChange={(event) => setFileForm((current) => ({ ...current, dedupeWindow: event.target.value }))}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="file-input">Select File</Label>
+                      <Input
+                        id="file-input"
+                        type="file"
+                        accept=".dex,.eva,.json,.txt,.csv"
+                        onChange={handleFileUploadChange}
+                        disabled={processing}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="file-idempotency">Idempotency Key</Label>
+                      <div className="flex gap-2">
+                        <Input
+                          id="file-idempotency"
+                          value={fileForm.idempotencyKey}
+                          onChange={(event) => setFileForm((current) => ({ ...current, idempotencyKey: event.target.value }))}
+                          required
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => setFileForm((current) => ({ ...current, idempotencyKey: createIdempotencyKey('file') }))}
+                        >
+                          <RefreshCw className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="file-metadata">Source Metadata (JSON)</Label>
+                    <Textarea
+                      id="file-metadata"
+                      value={fileForm.metadata}
+                      onChange={(event) => setFileForm((current) => ({ ...current, metadata: event.target.value }))}
+                      placeholder='{"siteId":"MEL-01","collection":"daily"}'
+                      className="min-h-[120px]"
                     />
                   </div>
 
-                  {processing && (
-                    <div className="text-center">
-                      <LoadingSpinner text="Processing file..." />
+                  <div className="flex items-center justify-between">
+                    <div className="text-sm text-slate-500">
+                      Files are normalized to the TelemetryEvent schema before ingestion.
                     </div>
-                  )}
-
-                  <div className="bg-blue-50 p-4 rounded-lg">
-                    <h4 className="font-medium text-blue-900 mb-2">Supported Formats</h4>
-                    <ul className="text-sm text-blue-800 space-y-1">
-                      <li><strong>DEX:</strong> Standard vending machine data exchange format</li>
-                      <li><strong>NAMA VDI:</strong> National Automatic Merchandising Association format</li>
-                      <li><strong>EVA-DTS:</strong> European Vending Association data transfer standard</li>
-                      <li><strong>JSON:</strong> Custom telemetry data in JSON format</li>
-                    </ul>
+                    <Button type="submit" disabled={processing}>
+                      {processing ? 'Normalizing…' : 'Normalize & Queue'}
+                    </Button>
                   </div>
-                </div>
+                </form>
+
+                {processing && (
+                  <div className="text-center mt-6">
+                    <LoadingSpinner text="Processing file..." />
+                  </div>
+                )}
+
+                {fileNormalizationResult && (
+                  <div className="mt-6 rounded-lg border border-green-200 bg-green-50 p-4">
+                    <h4 className="font-medium text-green-900">Normalization summary</h4>
+                    <p className="text-sm text-green-800 mt-1">
+                      {fileNormalizationResult.normalized_count ?? fileNormalizationResult.count ?? fileNormalizationResult?.normalized_events?.length ?? 0} events validated •
+                      {' '}
+                      {fileNormalizationResult.duplicates_suppressed ?? fileNormalizationResult.duplicatesSuppressed ?? ingestSummary.duplicateSuppression.suppressed} duplicates suppressed
+                    </p>
+                    {fileNormalizationResult.errors && fileNormalizationResult.errors.length > 0 && (
+                      <ul className="mt-2 list-disc list-inside text-sm text-red-700">
+                        {fileNormalizationResult.errors.map((error, index) => (
+                          <li key={`file-error-${index}`}>{error.message || error}</li>
+                        ))}
+                      </ul>
+                    )}
+                    <pre className="mt-3 max-h-64 overflow-auto rounded bg-white/80 p-3 text-xs text-slate-700">
+{JSON.stringify(fileNormalizationResult, null, 2)}
+                    </pre>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="mt-6">
+              <CardHeader>
+                <CardTitle>Submit Telemetry Events</CardTitle>
+                <CardDescription>
+                  Paste device payloads to normalize against the TelemetryEvent schema.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <form className="space-y-6" onSubmit={handleEventSubmit}>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="event-tenant">Tenant ID</Label>
+                      <Input
+                        id="event-tenant"
+                        value={eventForm.tenantId}
+                        onChange={(event) => setEventForm((current) => ({ ...current, tenantId: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="event-machine">Machine ID</Label>
+                      <Input
+                        id="event-machine"
+                        value={eventForm.machineId}
+                        onChange={(event) => setEventForm((current) => ({ ...current, machineId: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="event-device">Device ID</Label>
+                      <Input
+                        id="event-device"
+                        value={eventForm.deviceId}
+                        onChange={(event) => setEventForm((current) => ({ ...current, deviceId: event.target.value }))}
+                        placeholder="Optional device serial"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="event-schema">Schema Version</Label>
+                      <Input
+                        id="event-schema"
+                        value={eventForm.schemaVersion}
+                        onChange={(event) => setEventForm((current) => ({ ...current, schemaVersion: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Ingestion Channel</Label>
+                      <Select
+                        value={eventForm.ingestionChannel}
+                        onValueChange={(value) => setEventForm((current) => ({ ...current, ingestionChannel: value }))}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select channel" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="portal_api">Portal API</SelectItem>
+                          <SelectItem value="device_callback">Device callback</SelectItem>
+                          <SelectItem value="iot_gateway">IoT gateway</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="event-submitted">Submitted By</Label>
+                      <Input
+                        id="event-submitted"
+                        value={eventForm.submittedBy}
+                        onChange={(event) => setEventForm((current) => ({ ...current, submittedBy: event.target.value }))}
+                        placeholder="Operator or automation"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="event-metadata">Source Metadata (JSON)</Label>
+                    <Textarea
+                      id="event-metadata"
+                      value={eventForm.metadata}
+                      onChange={(event) => setEventForm((current) => ({ ...current, metadata: event.target.value }))}
+                      placeholder='{"batchId":"manual-001"}'
+                      className="min-h-[100px]"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="event-payload">Events JSON</Label>
+                    <Textarea
+                      id="event-payload"
+                      value={eventForm.eventsJson}
+                      onChange={(event) => setEventForm((current) => ({ ...current, eventsJson: event.target.value }))}
+                      placeholder='{"type":"vend","timestamp":"2024-01-01T00:00:00Z","amount":4.50}'
+                      className="min-h-[200px] font-mono"
+                      required
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="event-idempotency">Idempotency Key</Label>
+                      <div className="flex gap-2">
+                        <Input
+                          id="event-idempotency"
+                          value={eventForm.idempotencyKey}
+                          onChange={(event) => setEventForm((current) => ({ ...current, idempotencyKey: event.target.value }))}
+                          required
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => setEventForm((current) => ({ ...current, idempotencyKey: createIdempotencyKey('event') }))}
+                        >
+                          <RefreshCw className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <Button type="submit" disabled={submittingEvents} className="w-full md:w-auto">
+                    {submittingEvents ? 'Normalizing…' : 'Normalize & send'}
+                  </Button>
+                </form>
+
+                {submittingEvents && (
+                  <div className="text-center mt-6">
+                    <LoadingSpinner text="Normalizing events..." />
+                  </div>
+                )}
+
+                {eventNormalizationResult && (
+                  <div className="mt-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+                    <h4 className="font-medium text-blue-900">Event normalization summary</h4>
+                    <p className="text-sm text-blue-800 mt-1">
+                      {eventNormalizationResult.normalized_count ?? eventNormalizationResult.count ?? eventNormalizationResult?.normalized_events?.length ?? 0} events accepted
+                    </p>
+                    {eventNormalizationResult.warnings && eventNormalizationResult.warnings.length > 0 && (
+                      <ul className="mt-2 list-disc list-inside text-sm text-amber-700">
+                        {eventNormalizationResult.warnings.map((warning, index) => (
+                          <li key={`event-warning-${index}`}>{warning.message || warning}</li>
+                        ))}
+                      </ul>
+                    )}
+                    <pre className="mt-3 max-h-48 overflow-auto rounded bg-white/80 p-3 text-xs text-slate-700">
+{JSON.stringify(eventNormalizationResult, null, 2)}
+                    </pre>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
@@ -379,53 +1175,152 @@ export default function TelemetryPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-                  <Button
-                    variant="outline"
-                    onClick={() => handleExport('dex')}
-                    className="h-24 flex-col"
-                  >
-                    <FileText className="w-8 h-8 mb-2" />
-                    Export as DEX
+                <form className="space-y-6" onSubmit={handleExportSubmit}>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="export-tenant">Tenant ID</Label>
+                      <Input
+                        id="export-tenant"
+                        value={exportForm.tenantId}
+                        onChange={(event) => setExportForm((current) => ({ ...current, tenantId: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="export-machine">Machine ID</Label>
+                      <Input
+                        id="export-machine"
+                        value={exportForm.machineId}
+                        onChange={(event) => setExportForm((current) => ({ ...current, machineId: event.target.value }))}
+                        placeholder="Optional machine filter"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="export-start">Start Date</Label>
+                      <Input
+                        id="export-start"
+                        type="date"
+                        value={exportForm.startDate}
+                        onChange={(event) => setExportForm((current) => ({ ...current, startDate: event.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="export-end">End Date</Label>
+                      <Input
+                        id="export-end"
+                        type="date"
+                        value={exportForm.endDate}
+                        onChange={(event) => setExportForm((current) => ({ ...current, endDate: event.target.value }))}
+                        required
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    <Label>Data Types</Label>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                      {[{ label: 'Vend events', value: 'vend' }, { label: 'Error codes', value: 'errors' }, { label: 'Temperature', value: 'temperatures' }, { label: 'Energy', value: 'energy' }].map((option) => {
+                        const checked = exportForm.dataTypes.includes(option.value);
+                        return (
+                          <label key={option.value} className="flex items-center gap-3 rounded border p-3">
+                            <Checkbox
+                              id={`export-type-${option.value}`}
+                              checked={checked}
+                              onCheckedChange={(value) => {
+                                setExportForm((current) => {
+                                  const isChecked = Boolean(value);
+                                  const next = isChecked
+                                    ? Array.from(new Set([...current.dataTypes, option.value]))
+                                    : current.dataTypes.filter((type) => type !== option.value);
+                                  return { ...current, dataTypes: next };
+                                });
+                              }}
+                            />
+                            <span className="text-sm text-slate-700">{option.label}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label>Export Format</Label>
+                      <Select
+                        value={exportForm.format}
+                        onValueChange={(value) => setExportForm((current) => ({ ...current, format: value }))}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select format" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="jsonl">JSONL</SelectItem>
+                          <SelectItem value="parquet">Parquet</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="export-idempotency">Idempotency Key</Label>
+                      <div className="flex gap-2">
+                        <Input
+                          id="export-idempotency"
+                          value={exportForm.idempotencyKey}
+                          onChange={(event) => setExportForm((current) => ({ ...current, idempotencyKey: event.target.value }))}
+                          required
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => setExportForm((current) => ({ ...current, idempotencyKey: createIdempotencyKey('export') }))}
+                        >
+                          <RefreshCw className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex items-start gap-3">
+                    <Checkbox
+                      id="export-include-schema"
+                      checked={exportForm.includeSchema}
+                      onCheckedChange={(value) => setExportForm((current) => ({ ...current, includeSchema: Boolean(value) }))}
+                    />
+                    <div>
+                      <Label htmlFor="export-include-schema">Include schema metadata</Label>
+                      <p className="text-xs text-slate-500">Validated payloads will include TelemetryEvent schema descriptors.</p>
+                    </div>
+                  </div>
+
+                  <Button type="submit" disabled={exporting} className="w-full md:w-auto">
+                    {exporting ? 'Generating…' : 'Generate export'}
                   </Button>
-                  
-                  <Button
-                    variant="outline"
-                    onClick={() => handleExport('csv')}
-                    className="h-24 flex-col"
-                  >
-                    <FileText className="w-8 h-8 mb-2" />
-                    Export as CSV
-                  </Button>
-                  
-                  <Button
-                    variant="outline"
-                    onClick={() => handleExport('json')}
-                    className="h-24 flex-col"
-                  >
-                    <FileText className="w-8 h-8 mb-2" />
-                    Export as JSON
-                  </Button>
-                  
-                  <Button
-                    variant="outline"
-                    onClick={() => handleExport('parquet')}
-                    className="h-24 flex-col"
-                  >
-                    <FileText className="w-8 h-8 mb-2" />
-                    Export as Parquet
-                  </Button>
-                </div>
-                
-                <div className="mt-6 p-4 bg-amber-50 rounded-lg">
-                  <h4 className="font-medium text-amber-900 mb-2">Export Features</h4>
-                  <ul className="text-sm text-amber-800 space-y-1">
-                    <li>• Date range filtering</li>
-                    <li>• Machine-specific exports</li>
-                    <li>• Data type selection (vends, errors, temperatures)</li>
-                    <li>• Automatic file compression for large datasets</li>
-                  </ul>
-                </div>
+                </form>
+
+                {exportResult && (
+                  <div className="mt-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+                    <h4 className="font-medium text-blue-900">Export scheduled</h4>
+                    <p className="text-sm text-blue-800 mt-1">
+                      {exportResult.rows_exported ?? exportResult.count ?? 0} rows queued • Format {exportForm.format.toUpperCase()}
+                    </p>
+                    {exportResult.download_url && (
+                      <Button
+                        type="button"
+                        className="mt-3"
+                        variant="outline"
+                        onClick={() => window.open(exportResult.download_url, '_blank')}
+                      >
+                        <FileText className="w-4 h-4 mr-2" />Download export
+                      </Button>
+                    )}
+                    <pre className="mt-3 max-h-48 overflow-auto rounded bg-white/80 p-3 text-xs text-slate-700">
+{JSON.stringify(exportResult, null, 2)}
+                    </pre>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
@@ -444,7 +1339,7 @@ export default function TelemetryPage() {
                     <div key={machine.id} className="flex items-center justify-between p-4 border rounded-lg">
                       <div className="flex-1">
                         <div className="flex items-center gap-3">
-                          <Badge 
+                          <Badge
                             className={machine.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}
                           >
                             {machine.status}
@@ -475,12 +1370,103 @@ export default function TelemetryPage() {
                       <Button className="mt-4">Add Machine</Button>
                     </div>
                   )}
+
+                  {ingestSummary.deviceMappings.unmappedDevices?.length > 0 && (
+                    <div className="mt-6 border-t pt-4">
+                      <h4 className="font-medium text-slate-800 mb-2 flex items-center gap-2">
+                        <AlertTriangle className="w-4 h-4 text-amber-600" />
+                        Unmapped Devices
+                      </h4>
+                      <p className="text-sm text-slate-500 mb-3">
+                        These devices are emitting events but are not yet linked to a machine record.
+                      </p>
+                      <div className="space-y-2">
+                        {ingestSummary.deviceMappings.unmappedDevices.map((device) => (
+                          <div key={device.deviceId} className="rounded-lg border border-amber-200 bg-amber-50 p-3">
+                            <div className="flex items-center justify-between">
+                              <div>
+                                <p className="font-medium text-amber-900">Device {device.deviceId}</p>
+                                <p className="text-xs text-amber-700">Last event {device.lastSeen ? formatDistanceToNow(new Date(device.lastSeen), { addSuffix: true }) : 'unknown'}</p>
+                              </div>
+                              <Button variant="outline" size="sm">
+                                Map to machine
+                              </Button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               </CardContent>
             </Card>
           </TabsContent>
         </Tabs>
       </div>
+
+      <Dialog open={replayDialogOpen} onOpenChange={setReplayDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Replay failed message</DialogTitle>
+            <DialogDescription>
+              Requeue the selected payload using a new idempotency key and retry policy.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={handleReplaySubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="replay-tenant">Tenant ID</Label>
+              <Input
+                id="replay-tenant"
+                value={replayForm.tenantId}
+                onChange={(event) => setReplayForm((current) => ({ ...current, tenantId: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="replay-idempotency">Idempotency Key</Label>
+              <Input
+                id="replay-idempotency"
+                value={replayForm.idempotencyKey}
+                onChange={(event) => setReplayForm((current) => ({ ...current, idempotencyKey: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="replay-max-retries">Max Retries</Label>
+                <Input
+                  id="replay-max-retries"
+                  type="number"
+                  min={1}
+                  value={replayForm.maxRetries}
+                  onChange={(event) => setReplayForm((current) => ({ ...current, maxRetries: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Message ID</Label>
+                <Input value={selectedDeadLetter?.id || ''} disabled />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="replay-note">Replay Note</Label>
+              <Textarea
+                id="replay-note"
+                placeholder="Document the reason for replaying this payload"
+                value={replayForm.note}
+                onChange={(event) => setReplayForm((current) => ({ ...current, note: event.target.value }))}
+              />
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setReplayDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={replaying}>
+                {replaying ? 'Scheduling…' : 'Schedule Replay'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace prompt-driven telemetry actions with structured file and inline event forms that capture source metadata, idempotency keys, and submit through the TelemetryEvent normalization flow
- surface device-to-machine coverage, duplicate suppression, schema drift, gap alerts, and replay controls directly in the ingest monitor experience
- refresh API helper exports to provide safe access to Base44 functions including the new telemetry ingest, monitor, replay, and export endpoints, and add tenant-scoped JSONL/Parquet export tooling

## Testing
- npm run build *(fails: existing project import errors such as `Could not resolve "./dashboard" from "src/pages/index.jsx"`)*

------
https://chatgpt.com/codex/tasks/task_e_68dd37cff9cc8327960b33ba3ff97d1e