### PR TITLE
Fix Layout imports to use components alias

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,9 +1,9 @@
 
 import React, { Suspense } from 'react';
 import { Toaster } from 'sonner';
-import AppShell from './components/layout/AppShell';
-import { PageSkeleton } from './components/shared/Skeletons';
-import { Button } from './components/ui/button';
+import AppShell from '@/components/layout/AppShell';
+import { PageSkeleton } from '@/components/shared/Skeletons';
+import { Button } from '@/components/ui/button';
 import { AlertTriangle } from 'lucide-react';
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
 


### PR DESCRIPTION
## Summary
- update Layout page imports to use the shared @ alias for components

## Testing
- npm run build *(fails: Could not resolve "./dashboard" from "src/pages/index.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68dd4022043c83278085865f847fda86