### PR TITLE
Update Layout imports to use alias paths

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,9 +1,9 @@
 
 import React, { Suspense } from 'react';
 import { Toaster } from 'sonner';
-import AppShell from './components/layout/AppShell';
-import { PageSkeleton } from './components/shared/Skeletons';
-import { Button } from './components/ui/button';
+import AppShell from '@/components/layout/AppShell';
+import { PageSkeleton } from '@/components/shared/Skeletons';
+import { Button } from '@/components/ui/button';
 import { AlertTriangle } from 'lucide-react';
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
 


### PR DESCRIPTION
## Summary
- update the Layout page to import shared components via the configured alias paths

## Testing
- npm run build *(fails: Could not resolve "./dashboard" from "src/pages/index.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68dd40c2f3188327af563c4e22579df2