### PR TITLE
Refactor routing to use shared configuration array

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,306 +1,130 @@
 import Layout from "./Layout.jsx";
-
 import AdminAudit from "./AdminAudit";
-
 import ComplaintDetail from "./ComplaintDetail";
-
 import Report from "./Report";
-
 import XeroCallback from "./XeroCallback";
-
 import MapTest from "./MapTest";
-
 import dashboard from "./dashboard";
-
 import machines from "./machines";
-
 import routes from "./routes";
-
 import alerts from "./alerts";
-
 import locations from "./locations";
-
 import inventory from "./inventory";
-
 import sales from "./sales";
-
 import routeplanner from "./routeplanner";
-
 import finance from "./finance";
-
 import complaints from "./complaints";
-
 import servicetickets from "./servicetickets";
-
 import refunds from "./refunds";
-
 import aiinsights from "./aiinsights";
-
 import aiagent from "./aiagent";
-
 import users from "./users";
-
 import settings from "./settings";
-
 import help from "./help";
-
 import features from "./features";
-
 import telemetry from "./telemetry";
-
 import payments from "./payments";
-
 import mobile from "./mobile";
-
 import DeviceFleet from "./DeviceFleet";
-
 import energy from "./energy";
-
 import DeveloperPortal from "./DeveloperPortal";
-
 import developer from "./developer";
-
 import observability from "./observability";
-
 import FinancialIntegrations from "./FinancialIntegrations";
-
 import intelligence from "./intelligence";
-
 import machinedetail from "./machinedetail";
-
 import machineedit from "./machineedit";
-
 import routedetail from "./routedetail";
-
 import SecretsOnboarding from "./SecretsOnboarding";
-
 import Dashboard from "./Dashboard";
-
 import onboarding from "./onboarding";
-
 import HelpRadar from "./HelpRadar";
-
 import PublicDocsHome from "./PublicDocsHome";
-
 import PublicDoc from "./PublicDoc";
-
 import AiTrash from "./AiTrash";
-
 import analytics from "./analytics";
-
 import integrations from "./integrations";
-
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
-const PAGES = {
-    
-    AdminAudit: AdminAudit,
-    
-    ComplaintDetail: ComplaintDetail,
-    
-    Report: Report,
-    
-    XeroCallback: XeroCallback,
-    
-    MapTest: MapTest,
-    
-    dashboard: dashboard,
-    
-    machines: machines,
-    
-    routes: routes,
-    
-    alerts: alerts,
-    
-    locations: locations,
-    
-    inventory: inventory,
-    
-    sales: sales,
-    
-    routeplanner: routeplanner,
-    
-    finance: finance,
-    
-    complaints: complaints,
-    
-    servicetickets: servicetickets,
-    
-    refunds: refunds,
-    
-    aiinsights: aiinsights,
-    
-    aiagent: aiagent,
-    
-    users: users,
-    
-    settings: settings,
-    
-    help: help,
-    
-    features: features,
-    
-    telemetry: telemetry,
-    
-    payments: payments,
-    
-    mobile: mobile,
-    
-    DeviceFleet: DeviceFleet,
-    
-    energy: energy,
-    
-    DeveloperPortal: DeveloperPortal,
-    
-    developer: developer,
-    
-    observability: observability,
-    
-    FinancialIntegrations: FinancialIntegrations,
-    
-    intelligence: intelligence,
-    
-    machinedetail: machinedetail,
-    
-    machineedit: machineedit,
-    
-    routedetail: routedetail,
-    
-    SecretsOnboarding: SecretsOnboarding,
-    
-    Dashboard: Dashboard,
-    
-    onboarding: onboarding,
-    
-    HelpRadar: HelpRadar,
-    
-    PublicDocsHome: PublicDocsHome,
-    
-    PublicDoc: PublicDoc,
-    
-    AiTrash: AiTrash,
-    
-    analytics: analytics,
-    
-    integrations: integrations,
-    
-}
+export const routesConfig = [
+    { path: '/', name: 'AdminAudit', Component: AdminAudit },
+    { path: '/AdminAudit', name: 'AdminAudit', Component: AdminAudit },
+    { path: '/ComplaintDetail', name: 'ComplaintDetail', Component: ComplaintDetail },
+    { path: '/Report', name: 'Report', Component: Report },
+    { path: '/XeroCallback', name: 'XeroCallback', Component: XeroCallback },
+    { path: '/MapTest', name: 'MapTest', Component: MapTest },
+    { path: '/dashboard', name: 'dashboard', Component: dashboard },
+    { path: '/machines', name: 'machines', Component: machines },
+    { path: '/routes', name: 'routes', Component: routes },
+    { path: '/alerts', name: 'alerts', Component: alerts },
+    { path: '/locations', name: 'locations', Component: locations },
+    { path: '/inventory', name: 'inventory', Component: inventory },
+    { path: '/sales', name: 'sales', Component: sales },
+    { path: '/routeplanner', name: 'routeplanner', Component: routeplanner },
+    { path: '/finance', name: 'finance', Component: finance },
+    { path: '/complaints', name: 'complaints', Component: complaints },
+    { path: '/servicetickets', name: 'servicetickets', Component: servicetickets },
+    { path: '/refunds', name: 'refunds', Component: refunds },
+    { path: '/aiinsights', name: 'aiinsights', Component: aiinsights },
+    { path: '/aiagent', name: 'aiagent', Component: aiagent },
+    { path: '/users', name: 'users', Component: users },
+    { path: '/settings', name: 'settings', Component: settings },
+    { path: '/help', name: 'help', Component: help },
+    { path: '/features', name: 'features', Component: features },
+    { path: '/telemetry', name: 'telemetry', Component: telemetry },
+    { path: '/payments', name: 'payments', Component: payments },
+    { path: '/mobile', name: 'mobile', Component: mobile },
+    { path: '/DeviceFleet', name: 'DeviceFleet', Component: DeviceFleet },
+    { path: '/energy', name: 'energy', Component: energy },
+    { path: '/DeveloperPortal', name: 'DeveloperPortal', Component: DeveloperPortal },
+    { path: '/developer', name: 'developer', Component: developer },
+    { path: '/observability', name: 'observability', Component: observability },
+    { path: '/FinancialIntegrations', name: 'FinancialIntegrations', Component: FinancialIntegrations },
+    { path: '/intelligence', name: 'intelligence', Component: intelligence },
+    { path: '/machinedetail', name: 'machinedetail', Component: machinedetail },
+    { path: '/machineedit', name: 'machineedit', Component: machineedit },
+    { path: '/routedetail', name: 'routedetail', Component: routedetail },
+    { path: '/SecretsOnboarding', name: 'SecretsOnboarding', Component: SecretsOnboarding },
+    { path: '/Dashboard', name: 'Dashboard', Component: Dashboard },
+    { path: '/onboarding', name: 'onboarding', Component: onboarding },
+    { path: '/HelpRadar', name: 'HelpRadar', Component: HelpRadar },
+    { path: '/PublicDocsHome', name: 'PublicDocsHome', Component: PublicDocsHome },
+    { path: '/PublicDoc', name: 'PublicDoc', Component: PublicDoc },
+    { path: '/AiTrash', name: 'AiTrash', Component: AiTrash },
+    { path: '/analytics', name: 'analytics', Component: analytics },
+    { path: '/integrations', name: 'integrations', Component: integrations },
+];
 
-function _getCurrentPage(url) {
-    if (url.endsWith('/')) {
-        url = url.slice(0, -1);
-    }
-    let urlLastPart = url.split('/').pop();
-    if (urlLastPart.includes('?')) {
-        urlLastPart = urlLastPart.split('?')[0];
+const normalizePath = (path) => {
+    if (!path) {
+        return '/';
     }
 
-    const pageName = Object.keys(PAGES).find(page => page.toLowerCase() === urlLastPart.toLowerCase());
-    return pageName || Object.keys(PAGES)[0];
-}
+    const [pathname] = path.split('?');
+    if (!pathname || pathname === '/') {
+        return '/';
+    }
 
-// Create a wrapper component that uses useLocation inside the Router context
+    return pathname.replace(/\/+$/, '').toLowerCase();
+};
+
+const getCurrentPageName = (pathname) => {
+    const normalizedPath = normalizePath(pathname);
+    const matchingRoute = routesConfig.find(({ path }) => normalizePath(path) === normalizedPath);
+
+    return matchingRoute?.name ?? routesConfig[0].name;
+};
+
 function PagesContent() {
     const location = useLocation();
-    const currentPage = _getCurrentPage(location.pathname);
-    
+    const currentPageName = getCurrentPageName(location.pathname);
+
     return (
-        <Layout currentPageName={currentPage}>
-            <Routes>            
-                
-                    <Route path="/" element={<AdminAudit />} />
-                
-                
-                <Route path="/AdminAudit" element={<AdminAudit />} />
-                
-                <Route path="/ComplaintDetail" element={<ComplaintDetail />} />
-                
-                <Route path="/Report" element={<Report />} />
-                
-                <Route path="/XeroCallback" element={<XeroCallback />} />
-                
-                <Route path="/MapTest" element={<MapTest />} />
-                
-                <Route path="/dashboard" element={<dashboard />} />
-                
-                <Route path="/machines" element={<machines />} />
-                
-                <Route path="/routes" element={<routes />} />
-                
-                <Route path="/alerts" element={<alerts />} />
-                
-                <Route path="/locations" element={<locations />} />
-                
-                <Route path="/inventory" element={<inventory />} />
-                
-                <Route path="/sales" element={<sales />} />
-                
-                <Route path="/routeplanner" element={<routeplanner />} />
-                
-                <Route path="/finance" element={<finance />} />
-                
-                <Route path="/complaints" element={<complaints />} />
-                
-                <Route path="/servicetickets" element={<servicetickets />} />
-                
-                <Route path="/refunds" element={<refunds />} />
-                
-                <Route path="/aiinsights" element={<aiinsights />} />
-                
-                <Route path="/aiagent" element={<aiagent />} />
-                
-                <Route path="/users" element={<users />} />
-                
-                <Route path="/settings" element={<settings />} />
-                
-                <Route path="/help" element={<help />} />
-                
-                <Route path="/features" element={<features />} />
-                
-                <Route path="/telemetry" element={<telemetry />} />
-                
-                <Route path="/payments" element={<payments />} />
-                
-                <Route path="/mobile" element={<mobile />} />
-                
-                <Route path="/DeviceFleet" element={<DeviceFleet />} />
-                
-                <Route path="/energy" element={<energy />} />
-                
-                <Route path="/DeveloperPortal" element={<DeveloperPortal />} />
-                
-                <Route path="/developer" element={<developer />} />
-                
-                <Route path="/observability" element={<observability />} />
-                
-                <Route path="/FinancialIntegrations" element={<FinancialIntegrations />} />
-                
-                <Route path="/intelligence" element={<intelligence />} />
-                
-                <Route path="/machinedetail" element={<machinedetail />} />
-                
-                <Route path="/machineedit" element={<machineedit />} />
-                
-                <Route path="/routedetail" element={<routedetail />} />
-                
-                <Route path="/SecretsOnboarding" element={<SecretsOnboarding />} />
-                
-                <Route path="/Dashboard" element={<Dashboard />} />
-                
-                <Route path="/onboarding" element={<onboarding />} />
-                
-                <Route path="/HelpRadar" element={<HelpRadar />} />
-                
-                <Route path="/PublicDocsHome" element={<PublicDocsHome />} />
-                
-                <Route path="/PublicDoc" element={<PublicDoc />} />
-                
-                <Route path="/AiTrash" element={<AiTrash />} />
-                
-                <Route path="/analytics" element={<analytics />} />
-                
-                <Route path="/integrations" element={<integrations />} />
-                
+        <Layout currentPageName={currentPageName}>
+            <Routes>
+                {routesConfig.map(({ path, Component }) => (
+                    <Route key={path} path={path} element={<Component />} />
+                ))}
             </Routes>
         </Layout>
     );


### PR DESCRIPTION
## Summary
- replace the PAGES registry and hand-written <Route> declarations with a single exported routesConfig array
- derive the current page name and router tree directly from the shared configuration to remove duplication

## Testing
- npm run build *(fails: Could not resolve "./dashboard" from "src/pages/index.jsx" – pre-existing missing module)*

------
https://chatgpt.com/codex/tasks/task_e_68dd40c61ee88327a5690464afd624e5