### PR TITLE
Fix dashboard component import reference

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -10,7 +10,6 @@ import XeroCallback from "./XeroCallback";
 
 import MapTest from "./MapTest";
 
-import dashboard from "./dashboard";
 
 import machines from "./machines";
 
@@ -104,7 +103,7 @@ const PAGES = {
     
     MapTest: MapTest,
     
-    dashboard: dashboard,
+    dashboard: Dashboard,
     
     machines: machines,
     
@@ -221,7 +220,7 @@ function PagesContent() {
                 
                 <Route path="/MapTest" element={<MapTest />} />
                 
-                <Route path="/dashboard" element={<dashboard />} />
+                <Route path="/dashboard" element={<Dashboard />} />
                 
                 <Route path="/machines" element={<machines />} />
                 


### PR DESCRIPTION
## Summary
- remove the invalid lowercase dashboard import from the pages index
- map the dashboard route and page registry to the existing Dashboard component

## Testing
- npm run build *(fails: missing react-markdown dependency in src/pages/help.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd46e6b0d083278e4d163d95b33710