### PR TITLE
Fix layout component import paths

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,9 +1,9 @@
 
 import React, { Suspense } from 'react';
 import { Toaster } from 'sonner';
-import AppShell from './components/layout/AppShell';
-import { PageSkeleton } from './components/shared/Skeletons';
-import { Button } from './components/ui/button';
+import AppShell from '../components/layout/AppShell';
+import { PageSkeleton } from '../components/shared/Skeletons';
+import { Button } from '../components/ui/button';
 import { AlertTriangle } from 'lucide-react';
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
 


### PR DESCRIPTION
## Summary
- update Layout page to import AppShell, PageSkeleton, and Button from the shared components directory

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: existing syntax error in src/api/functions.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dd51b42e108327b5776091eede307c